### PR TITLE
ruy: fix cpuinfo requirement to avoid conflict

### DIFF
--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -60,7 +60,10 @@ class RuyConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def requirements(self):
-        self.requires("cpuinfo/cci.20231129")
+        if self.version == "cci.20220628":
+            self.requires("cpuinfo/cci.20220228")
+        else:
+            self.requires("cpuinfo/cci.20231129")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/xnnpack/all/conanfile.py
+++ b/recipes/xnnpack/all/conanfile.py
@@ -59,7 +59,10 @@ class XnnpackConan(ConanFile):
             self.requires("cpuinfo/cci.20231129")
         self.requires("fp16/cci.20210320")
         #  https://github.com/google/XNNPACK/blob/ed5f9c0562e016a08b274a4579de5ef500fec134/include/xnnpack.h#L15
-        self.requires("pthreadpool/cci.20231129", transitive_headers=True)
+        if self.version <= "cci.20230715":
+            self.requires("pthreadpool/cci.20210218", transitive_headers=True)
+        else:
+            self.requires("pthreadpool/cci.20231129", transitive_headers=True)
         self.requires("fxdiv/cci.20200417")
 
     def validate(self):


### PR DESCRIPTION
In the commit 8296da4ef `(#21760) ruy: Add cci.20231129` a new ruy version was added to recipes/ruy/config.yml, with the cpuinfo requirement changed from cpuinfo/cci.20220228 to cpuinfo/cci.20231129.

However this was done in a way that also affected the cpuinfo requirement for the older ruy/cci.20220628 version, which causes a dependency conflict for [tensorflow-lite-imx](https://github.com/Huddly/falcon-dependencies/blob/0a10e2b006329e86abf37d261f1fe4f38236d374/recipes/tensorflow-lite-imx/all/conanfile.py#L82) where ruy/cci.20220628 and xnnpack/cci.20220801 is required from the same recipe.

This fixes the problem by conditionally requiring the old cpuinfo version for the old ruy version.
